### PR TITLE
Add Science takedown support

### DIFF
--- a/app/controllers/api/v1/issues_controller.rb
+++ b/app/controllers/api/v1/issues_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::IssuesController < Api::V1::ApplicationController
   def index
     scope = Issue.where(pull_request: false, state: 'open').includes(:project)
-    scope = scope.joins(:project).good_first_issue
+    scope = scope.joins(:project).merge(Project.visible).good_first_issue
 
     # Apply filters if provided
     scope = scope.joins(:project).where(projects: { category: params[:category] }) if params[:category].present?

--- a/app/controllers/api/v1/projects_controller.rb
+++ b/app/controllers/api/v1/projects_controller.rb
@@ -1,6 +1,6 @@
 class Api::V1::ProjectsController < Api::V1::ApplicationController
   def index
-    @projects = Project.all.where.not(last_synced_at: nil)
+    @projects = Project.visible.where.not(last_synced_at: nil)
 
 
     if params[:sort].present? || params[:order].present?
@@ -16,30 +16,32 @@ class Api::V1::ProjectsController < Api::V1::ApplicationController
   end
 
   def show
-    @project = Project.find(params[:id])
+    @project = Project.visible.find(params[:id])
   end
 
   def lookup
-    @project = Project.find_by(url: params[:url].downcase)
+    @project = Project.visible.find_by(url: params[:url].downcase)
     if @project.nil?
       @project = Project.create(url: params[:url].downcase)
+      raise ActiveRecord::RecordNotFound unless @project.persisted?
+
       @project.sync_async
     end
     @project.sync_async if @project.last_synced_at.nil? || @project.last_synced_at < 1.day.ago
   end
 
   def ping
-    @project = Project.find(params[:id])
+    @project = Project.visible.find(params[:id])
     @project.sync_async
     render json: { message: 'pong' }
   end
 
   def packages
-    @projects = Project.active.select{|p| p.packages.present? }.sort_by{|p| p.packages.sum{|p| p['downloads'] || 0 } }.reverse
+    @projects = Project.visible.active.select{|p| p.packages.present? }.sort_by{|p| p.packages.sum{|p| p['downloads'] || 0 } }.reverse
   end
 
   def search
-    @scope = Project
+    @scope = Project.visible
 
     if params[:q].present?
       @scope = @scope.where("url ILIKE ?", "%#{params[:q]}%")

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -8,11 +8,11 @@ class CategoriesController < ApplicationController
     @category = params[:id]
     if params[:sub_category]  
       @sub_category = params[:sub_category]
-      project_scope = Project.where(category: @category, sub_category: @sub_category).order('score DESC')
-      contributor_scope = Contributor.category(@category).sub_category(@sub_category).display.order('name ASC')
+      project_scope = Project.visible.where(category: @category, sub_category: @sub_category).order('score DESC')
+      contributor_scope = Contributor.visible.category(@category).sub_category(@sub_category).display.order('name ASC')
     else
-      project_scope = Project.where(category: @category).order('score DESC')
-      contributor_scope = Contributor.category(@category).display.order('name ASC')
+      project_scope = Project.visible.where(category: @category).order('score DESC')
+      contributor_scope = Contributor.visible.category(@category).display.order('name ASC')
     end
     @sub_categories = @categories.find { |category| category[:category] == @category }[:sub_categories]
     

--- a/app/controllers/contributors_controller.rb
+++ b/app/controllers/contributors_controller.rb
@@ -1,10 +1,10 @@
 class ContributorsController < ApplicationController
   def index
-    scope = Contributor.display.order('last_synced_at DESC')
+    scope = Contributor.visible.display.order('last_synced_at DESC')
     @pagy, @contributors = pagy(scope)
   end
 
   def show
-    @contributor = Contributor.find(params[:id])
+    @contributor = Contributor.visible.find(params[:id])
   end
 end

--- a/app/controllers/fields_controller.rb
+++ b/app/controllers/fields_controller.rb
@@ -18,6 +18,8 @@ class FieldsController < ApplicationController
 
     # Get projects in this field with their confidence scores
     @pagy, @project_fields = pagy(@field.project_fields
+                                        .joins(:project)
+                                        .merge(Project.visible)
                                         .includes(:project)
                                         .order(confidence_score: :desc),
                                   items: 20)
@@ -49,9 +51,10 @@ class FieldsController < ApplicationController
     field_stats = {}
 
     # Get counts per field
-    counts = ProjectField.group(:field_id).count
+    visible_project_fields = ProjectField.joins(:project).merge(Project.visible)
+    counts = visible_project_fields.group(:field_id).count
     # Get averages per field
-    averages = ProjectField.group(:field_id).average(:confidence_score)
+    averages = visible_project_fields.group(:field_id).average(:confidence_score)
 
     Field.all.each do |field|
       project_count = counts[field.id] || 0
@@ -65,12 +68,13 @@ class FieldsController < ApplicationController
   end
 
   def calculate_field_show_stats(field)
+    project_fields = field.project_fields.joins(:project).merge(Project.visible)
     {
-      total_projects: field.project_fields.count,
-      avg_confidence: field.project_fields.average(:confidence_score)&.round(2),
-      high_confidence_count: field.project_fields.where('confidence_score >= ?', 0.7).count,
-      medium_confidence_count: field.project_fields.where('confidence_score >= ? AND confidence_score < ?', 0.5, 0.7).count,
-      low_confidence_count: field.project_fields.where('confidence_score < ?', 0.5).count
+      total_projects: project_fields.count,
+      avg_confidence: project_fields.average(:confidence_score)&.round(2),
+      high_confidence_count: project_fields.where('confidence_score >= ?', 0.7).count,
+      medium_confidence_count: project_fields.where('confidence_score >= ? AND confidence_score < ?', 0.5, 0.7).count,
+      low_confidence_count: project_fields.where('confidence_score < ?', 0.5).count
     }
   end
 
@@ -78,7 +82,7 @@ class FieldsController < ApplicationController
     return [] unless field.project_fields.any?
 
     keyword_counts = Hash.new(0)
-    field.projects.limit(100).each do |project|
+    field.projects.merge(Project.visible).limit(100).each do |project|
       if project.keywords.present? && project.keywords.is_a?(Array)
         project.keywords.each do |keyword|
           keyword_counts[keyword.to_s] += 1 if keyword.present?

--- a/app/controllers/hosts_controller.rb
+++ b/app/controllers/hosts_controller.rb
@@ -6,7 +6,7 @@ class HostsController < ApplicationController
   end
 
   def show
-    @scope = @host.projects.where('science_score > 0')
+    @scope = @host.projects.visible.where('science_score > 0')
 
     if params[:sort]
       @scope = @scope.order("#{params[:sort]} #{params[:order]}")

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -1,6 +1,6 @@
 class IssuesController < ApplicationController
   def index
-    scope = Issue.good_first_issue.joins(:project).includes(:project)
+    scope = Issue.good_first_issue.joins(:project).merge(Project.visible).includes(:project)
 
     # Apply filters if provided
     scope = scope.joins(:project).where(projects: { category: params[:category] }) if params[:category].present?

--- a/app/controllers/owners_controller.rb
+++ b/app/controllers/owners_controller.rb
@@ -7,16 +7,16 @@ class OwnersController < ApplicationController
   end
 
   def index
-    scope = @host.owners.order('projects_count DESC')
+    scope = @host.owners.visible.order('projects_count DESC')
     @pagy, @owners = pagy(scope)
   end
 
   def show
     @owner = params[:id]
     @owner_record = @host.owners.find_by('lower(login) = ?', @owner.downcase)
-    raise ActiveRecord::RecordNotFound unless @owner_record
+    raise ActiveRecord::RecordNotFound if @owner_record.nil? || @owner_record.hidden?
 
-    @scope = Project.where(owner_record: @owner_record).where('science_score > 0')
+    @scope = Project.visible.where(owner_record: @owner_record).where('science_score > 0')
 
     if params[:sort]
       @scope = @scope.order("#{params[:sort]} #{params[:order]}")

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,10 +1,10 @@
 class ProjectsController < ApplicationController
   def show
-    @project = Project.includes(:host, :owner_record, papers: :mentions).find(params[:id])
+    @project = Project.visible.includes(:host, :owner_record, papers: :mentions).find(params[:id])
   end
 
   def export
-    @project = Project.find(params[:id])
+    @project = Project.visible.find(params[:id])
     format = params[:format] || 'bibtex'
 
     exported_content = @project.export_citation(format: format)
@@ -28,7 +28,7 @@ class ProjectsController < ApplicationController
   end
 
   def index
-    @scope = Project.includes(project_fields: :field).where('science_score > 0')
+    @scope = Project.visible.includes(project_fields: :field).where('science_score > 0')
 
     if params[:keyword].present?
       @scope = @scope.keyword(params[:keyword])
@@ -52,7 +52,7 @@ class ProjectsController < ApplicationController
   end
 
   def search
-    @scope = Project.where('science_score > 0')
+    @scope = Project.visible.where('science_score > 0')
 
     if params[:q].present?
       @scope = @scope.where("url ILIKE ?", "%#{params[:q]}%")
@@ -77,7 +77,7 @@ class ProjectsController < ApplicationController
   end
 
   def review
-    @scope = Project.matching_criteria
+    @scope = Project.visible.matching_criteria
 
     if params[:keyword].present?
       @scope = @scope.keyword(params[:keyword])
@@ -108,6 +108,8 @@ class ProjectsController < ApplicationController
     # Check for existing project first
     existing_project = Project.find_by(url: params[:project][:url].downcase)
     if existing_project
+      raise ActiveRecord::RecordNotFound if existing_project.hidden_owner?
+
       redirect_to existing_project
     else
       @project = Project.new(project_params)
@@ -129,7 +131,7 @@ class ProjectsController < ApplicationController
   end
 
   def joss
-    @scope = Project.where("joss_metadata IS NOT NULL")
+    @scope = Project.visible.where("joss_metadata IS NOT NULL")
 
     if params[:keyword].present?
       @scope = @scope.keyword(params[:keyword])
@@ -149,7 +151,7 @@ class ProjectsController < ApplicationController
   end
 
   def codemeta
-    @scope = Project.with_codemeta_file
+    @scope = Project.visible.with_codemeta_file
 
     if params[:keyword].present?
       @scope = @scope.keyword(params[:keyword])
@@ -169,7 +171,7 @@ class ProjectsController < ApplicationController
   end
 
   def citation
-    @scope = Project.with_citation_file
+    @scope = Project.visible.with_citation_file
 
     if params[:keyword].present?
       @scope = @scope.keyword(params[:keyword])
@@ -189,7 +191,7 @@ class ProjectsController < ApplicationController
   end
 
   def codemeta_csv
-    projects = Project.with_codemeta_file
+    projects = Project.visible.with_codemeta_file
 
     csv_data = CSV.generate(headers: true) do |csv|
       csv << ['repository_url', 'codemeta_file_path']
@@ -205,7 +207,7 @@ class ProjectsController < ApplicationController
   end
 
   def citation_csv
-    projects = Project.with_citation_file
+    projects = Project.visible.with_citation_file
 
     csv_data = CSV.generate(headers: true) do |csv|
       csv << ['repository_url', 'citation_file_path']
@@ -221,7 +223,7 @@ class ProjectsController < ApplicationController
   end
 
   def zenodo
-    @scope = Project.with_zenodo_file
+    @scope = Project.visible.with_zenodo_file
 
     if params[:keyword].present?
       @scope = @scope.keyword(params[:keyword])
@@ -241,7 +243,7 @@ class ProjectsController < ApplicationController
   end
 
   def zenodo_csv
-    projects = Project.with_zenodo_file
+    projects = Project.visible.with_zenodo_file
 
     csv_data = CSV.generate(headers: true) do |csv|
       csv << ['repository_url', 'zenodo_file_path']

--- a/app/controllers/releases_controller.rb
+++ b/app/controllers/releases_controller.rb
@@ -1,9 +1,9 @@
 class ReleasesController < ApplicationController
   def index
-    @releases = Release.all.order('published_at DESC')
+    @releases = Release.joins(:project).merge(Project.visible).order('published_at DESC')
 
     if params[:project_id]
-      @project = Project.find(params[:project_id])
+      @project = Project.visible.find(params[:project_id])
       @releases = @releases.where(project_id: params[:project_id])
     end
 
@@ -11,6 +11,6 @@ class ReleasesController < ApplicationController
   end
 
   def show
-    @release = Release.find(params[:id])
+    @release = Release.joins(:project).merge(Project.visible).find(params[:id])
   end
 end

--- a/app/models/contributor.rb
+++ b/app/models/contributor.rb
@@ -16,6 +16,16 @@ class Contributor < ApplicationRecord
   scope :with_funding_links, -> { where("LENGTH(profile ->> 'funding_links') > 2") }
 
   scope :ignored_emails, -> { where.not(email: IGNORED_EMAILS) }
+  scope :visible, -> {
+    where(<<~SQL.squish)
+      NOT EXISTS (
+        SELECT 1
+        FROM owners
+        WHERE owners.hidden = TRUE
+          AND lower(owners.login) = lower(COALESCE(contributors.login, contributors.profile ->> 'login'))
+      )
+    SQL
+  }
 
   scope :category, ->(category) { where("categories @> ARRAY[?]::varchar[]", category) }
   scope :sub_category, ->(sub_category) { where("sub_categories @> ARRAY[?]::varchar[]", sub_category) }
@@ -50,6 +60,7 @@ class Contributor < ApplicationRecord
   end
 
   def fetch_profile
+    return if owner_hidden?
     return if repos_api_url.blank?
     
     response = self.class.ecosystem_http_get(repos_api_url)
@@ -60,6 +71,7 @@ class Contributor < ApplicationRecord
   end
 
   def import_repos
+    return if owner_hidden?
     return if repos_api_url.blank?
 
     response = self.class.ecosystem_http_get("#{repos_api_url}/repositories?per_page=1000")
@@ -76,5 +88,12 @@ class Contributor < ApplicationRecord
 
   def owned_projects
     Project.owner(login)
+  end
+
+  def owner_hidden?
+    owner_login = login.presence || profile['login']
+    return false if owner_login.blank?
+
+    Owner.hidden.where('lower(login) = ?', owner_login.downcase).exists?
   end
 end

--- a/app/models/owner.rb
+++ b/app/models/owner.rb
@@ -10,11 +10,13 @@ class Owner < ApplicationRecord
   validates :login, uniqueness: { scope: :host_id, case_sensitive: false }
   validates :uuid, uniqueness: { scope: :host_id }, allow_nil: true
 
+  scope :hidden, -> { where(hidden: true) }
+  scope :visible, -> { where(hidden: [false, nil]) }
   scope :organizations, -> { where(kind: 'organization') }
   scope :institutional, -> {
     # Build SQL conditions to match any academic domain
     conditions = ACADEMIC_DOMAINS.map { |domain| "LOWER(website) LIKE '%#{sanitize_sql_like(domain)}%'" }.join(' OR ')
-    organizations.where("website IS NOT NULL AND website != '' AND (#{conditions})")
+    organizations.visible.where("website IS NOT NULL AND website != '' AND (#{conditions})")
   }
 
   def institutional?
@@ -25,6 +27,27 @@ class Owner < ApplicationRecord
     return false unless domain
 
     ACADEMIC_DOMAINS.any? { |academic_domain| domain.include?(academic_domain) }
+  end
+
+  def hide!
+    update!(
+      hidden: true,
+      name: nil,
+      uuid: nil,
+      description: nil,
+      email: nil,
+      website: nil,
+      location: nil,
+      twitter: nil,
+      company: nil,
+      icon_url: nil,
+      repositories_count: 0,
+      last_synced_at: nil,
+      metadata: {},
+      total_stars: nil,
+      followers: nil,
+      following: nil
+    )
   end
 
   def extract_domain(url)

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -19,6 +19,7 @@ class Project < ApplicationRecord
   end
 
   validates :url, presence: true, uniqueness: { case_sensitive: false }
+  validate :owner_not_hidden
 
   belongs_to :host, optional: true
   belongs_to :owner_record, class_name: 'Owner', foreign_key: 'owner_id', optional: true
@@ -32,9 +33,14 @@ class Project < ApplicationRecord
   has_many :fields, through: :project_fields
   has_many :mentions, dependent: :destroy
   has_many :papers, through: :mentions
+  has_many :dependency_records, class_name: 'Dependency', dependent: :nullify
+  has_many :votes, dependent: :delete_all
 
   has_many :good_first_issues, -> { good_first_issue }, class_name: 'Issue'
 
+  scope :visible, -> {
+    where(owner_id: nil).or(where.not(owner_id: Owner.hidden.select(:id)))
+  }
   scope :active, -> { where("(repository ->> 'archived') = ?", 'false') }
   scope :archived, -> { where("(repository ->> 'archived') = ?", 'true') }
 
@@ -64,6 +70,44 @@ class Project < ApplicationRecord
   scope :scientific, -> { where('science_score >= ?', 20) }
   scope :highly_scientific, -> { where('science_score >= ?', 75) }
   scope :should_sync, -> { where('last_synced_at IS NULL OR science_score IS NULL OR science_score > 0') }
+
+  def self.for_owner(host, login)
+    normalized_login = login.downcase
+    owner_ids = host.owners.where('lower(login) = ?', normalized_login).select(:id)
+
+    scope = unscoped.where(owner_id: owner_ids)
+    scope = scope.or(
+      unscoped.where(host_id: host.id).where(
+        "lower(repository ->> 'owner') = :login OR lower(owner ->> 'login') = :login",
+        login: normalized_login
+      )
+    )
+
+    host_urls = [host.url]
+    host_urls << 'https://github.com' if host.name.casecmp?('GitHub')
+    host_urls.compact.map { |url| url.downcase.chomp('/') }.uniq.each do |host_url|
+      escaped_login = sanitize_sql_like(normalized_login)
+      scope = scope.or(unscoped.where('lower(url) LIKE ?', "#{host_url}/#{escaped_login}/%"))
+    end
+
+    scope
+  end
+
+  def self.owner_details_from_url(url)
+    uri = URI.parse(url.to_s)
+    return [nil, nil] if uri.host.blank?
+
+    if uri.host.downcase.end_with?('.github.io')
+      return [Host.find_by_name('GitHub'), uri.host.split('.').first]
+    end
+
+    owner_login = uri.path.split('/').reject(&:blank?).first
+    owner_host = Host.find_by_name(uri.host)
+    owner_host ||= Host.find_by_name(uri.host.split('.').first)
+    [owner_host, owner_login]
+  rescue URI::InvalidURIError
+    [nil, nil]
+  end
 
   def self.import_from_csv(url)
     conn = Faraday.new(url: url) do |faraday|
@@ -281,12 +325,16 @@ class Project < ApplicationRecord
   end
 
   def sync
+    return if hidden_owner?
+
     check_url
     return unless self.persisted?
     fetch_repository
     find_or_create_host
     fetch_owner
     find_or_create_owner
+    return if hidden_owner?
+
     fetch_dependencies
     fetch_packages
     import_mentions
@@ -309,6 +357,9 @@ class Project < ApplicationRecord
   end
 
   def sync_async
+    return if hidden_owner?
+    return unless persisted?
+
     SyncProjectWorker.perform_async(id)
   end
 
@@ -458,10 +509,15 @@ class Project < ApplicationRecord
     return unless host.present?
     return unless owner_data['login'].present?
 
-    owner_record = Owner.find_or_initialize_by(
-      host: host,
-      login: owner_data['login'].downcase
-    )
+    owner_record = host.owners.find_by('lower(login) = ?', owner_data['login'].downcase)
+    if owner_record&.hidden? || owner_data['hidden'] == true
+      owner_record ||= host.owners.build(login: owner_data['login'].downcase)
+      owner_record.hide!
+      self.update_column(:owner_id, owner_record.id)
+      return owner_record
+    end
+
+    owner_record ||= host.owners.build(login: owner_data['login'].downcase)
 
     owner_record.assign_attributes(
       name: owner_data['name'],
@@ -480,7 +536,7 @@ class Project < ApplicationRecord
       total_stars: owner_data['total_stars'],
       followers: owner_data['followers'],
       following: owner_data['following'],
-      hidden: owner_data['hidden']
+      hidden: owner_record.hidden? ? true : owner_data['hidden']
     )
     owner_record.save
 
@@ -746,6 +802,28 @@ class Project < ApplicationRecord
   def owner_name
     return unless repository.present?
     repository['owner']
+  end
+
+  def hidden_owner?
+    return true if owner_record&.hidden?
+
+    owner_data = read_attribute(:owner)
+    return true if owner_data.is_a?(Hash) && owner_data['hidden'] == true
+
+    repository_data = read_attribute(:repository)
+    url_host, url_login = self.class.owner_details_from_url(url)
+    owner_host = host || url_host
+    owner_login = owner_data['login'] if owner_data.is_a?(Hash)
+    owner_login ||= repository_data['owner'] if repository_data.is_a?(Hash)
+    owner_login ||= url_login
+
+    return false if owner_host.nil? || owner_login.blank?
+
+    owner_host.owners.hidden.where('lower(login) = ?', owner_login.downcase).exists?
+  end
+
+  def owner_not_hidden
+    errors.add(:url, 'belongs to a hidden owner') if hidden_owner?
   end
 
   def avatar_url
@@ -1095,7 +1173,7 @@ class Project < ApplicationRecord
     # Extract unique GitHub owner names from projects with reasonable science score
     owners = []
     
-    scope = Project.with_repository
+    scope = Project.visible.with_repository
     scope = scope.where('science_score >= ?', min_science_score) if min_science_score > 0
     
     scope.find_each do |project|
@@ -1170,7 +1248,8 @@ class Project < ApplicationRecord
 
   def self.packages_sorted_ids
     Rails.cache.fetch('packages_projects_ids', expires_in: 2.hours) do
-      with_packages
+      visible
+        .with_packages
         .where('science_score > 0')
         .sort_by { |p| p.packages.sum { |pkg| pkg['downloads'] || 0 } }
         .reverse
@@ -1180,7 +1259,7 @@ class Project < ApplicationRecord
 
   def self.packages_sorted
     project_ids = packages_sorted_ids
-    Project.where(id: project_ids).index_by(&:id).values_at(*project_ids).compact
+    Project.visible.where(id: project_ids).index_by(&:id).values_at(*project_ids).compact
   end
 
   def self.all_package_and_project_names
@@ -1193,35 +1272,36 @@ class Project < ApplicationRecord
   end
 
   def self.stats_summary
-    total_projects = Project.count
-    scored_projects = Project.where.not(science_score: nil).count
+    scope = Project.visible
+    total_projects = scope.count
+    scored_projects = scope.where.not(science_score: nil).count
 
     # Science score distribution
-    score_distribution = Project.group(:science_score).count
-    scientific_count = Project.scientific.count
-    highly_scientific_count = Project.highly_scientific.count
+    score_distribution = scope.group(:science_score).count
+    scientific_count = scope.scientific.count
+    highly_scientific_count = scope.highly_scientific.count
 
     # Calculate averages for scored projects
-    median_score = Project.where.not(science_score: nil).median(:science_score) rescue nil
+    median_score = scope.where.not(science_score: nil).median(:science_score) rescue nil
 
     # Repository stats
-    with_repo_count = Project.with_repository.count
-    with_readme_count = Project.with_readme.count
-    with_packages_count = Project.with_packages.count
+    with_repo_count = scope.with_repository.count
+    with_readme_count = scope.with_readme.count
+    with_packages_count = scope.with_packages.count
 
     # Citation and metadata file counts
-    with_citation_count = Project.where.not(citation_file: nil).count
-    with_codemeta_count = Project.with_codemeta_file.count
-    with_zenodo_count = Project.with_zenodo_file.count
+    with_citation_count = scope.where.not(citation_file: nil).count
+    with_codemeta_count = scope.with_codemeta_file.count
+    with_zenodo_count = scope.with_zenodo_file.count
 
     # JOSS stats
-    joss_count = Project.with_joss.count
+    joss_count = scope.with_joss.count
 
     # Institutional owners stats
     institutional_owners_count = Owner.institutional.count
 
     # Language distribution (top 10)
-    language_distribution = Project.with_repository
+    language_distribution = scope.with_repository
       .where('science_score > 0')
       .where.not(repository: nil)
       .where("repository->>'language' IS NOT NULL")
@@ -2323,23 +2403,16 @@ class Project < ApplicationRecord
   end
 
   def self.category_tree
-    sql = <<-SQL
-      SELECT category, sub_category, COUNT(*)
-      FROM projects
-      WHERE 1=1 
-      GROUP BY category, sub_category
-    SQL
+    results = visible.group(:category, :sub_category).count
 
-    results = ActiveRecord::Base.connection.execute(sql)
-
-    results.group_by { |row| row['category'] }.map do |category, rows|
+    results.group_by { |(category, _), _| category }.map do |category, rows|
       {
         category: category,
-        count: rows.sum { |row| row['count'] },
-        sub_categories: rows.map do |row|
+        count: rows.sum { |_, count| count },
+        sub_categories: rows.map do |(_, sub_category), count|
           {
-            sub_category: row['sub_category'],
-            count: row['count']
+            sub_category: sub_category,
+            count: count
           }
         end
       }

--- a/app/models/vote.rb
+++ b/app/models/vote.rb
@@ -1,0 +1,3 @@
+class Vote < ApplicationRecord
+  belongs_to :project
+end

--- a/app/views/fields/index.html.erb
+++ b/app/views/fields/index.html.erb
@@ -25,7 +25,7 @@
     <div class="col-md-3">
       <div class="card text-center">
         <div class="card-body">
-          <h3 class="text-success"><%= ProjectField.distinct.count(:project_id) %></h3>
+          <h3 class="text-success"><%= ProjectField.joins(:project).merge(Project.visible).distinct.count(:project_id) %></h3>
           <p class="text-muted mb-0">Classified Projects</p>
         </div>
       </div>
@@ -33,7 +33,7 @@
     <div class="col-md-3">
       <div class="card text-center">
         <div class="card-body">
-          <h3 class="text-info"><%= (ProjectField.average(:confidence_score) * 100).round(1) %>%</h3>
+          <h3 class="text-info"><%= (ProjectField.joins(:project).merge(Project.visible).average(:confidence_score) * 100).round(1) %>%</h3>
           <p class="text-muted mb-0">Avg Confidence</p>
         </div>
       </div>
@@ -41,7 +41,7 @@
     <div class="col-md-3">
       <div class="card text-center">
         <div class="card-body">
-          <h3 class="text-warning"><%= Project.joins(:project_fields).group('projects.id').having('COUNT(project_fields.id) > 1').count.size %></h3>
+          <h3 class="text-warning"><%= Project.visible.joins(:project_fields).group('projects.id').having('COUNT(project_fields.id) > 1').count.size %></h3>
           <p class="text-muted mb-0">Multi-field Projects</p>
         </div>
       </div>

--- a/lib/tasks/takedown.rake
+++ b/lib/tasks/takedown.rake
@@ -1,0 +1,58 @@
+namespace :takedown do
+  desc "Hide a user and remove their projects. LOGIN=username [HOST=GitHub]"
+  task hide_user: :environment do
+    login = ENV['LOGIN']
+    host_name = ENV['HOST'] || 'GitHub'
+    abort "LOGIN is required" if login.blank?
+
+    host = Host.find_by_name(host_name)
+    abort "Host #{host_name} not found" if host.nil?
+
+    owner = nil
+    project_count = 0
+    contributor_count = 0
+
+    ActiveRecord::Base.transaction do
+      owner = host.owners.find_by('lower(login) = ?', login.downcase)
+      owner ||= host.owners.create!(login: login.downcase)
+      owner.hide!
+
+      projects = Project.for_owner(host, login)
+      project_count = projects.count
+      projects.find_each(&:destroy!)
+
+      contributors = Contributor.where(
+        "lower(login) = :login OR lower(profile ->> 'login') = :login",
+        login: login.downcase
+      )
+      contributor_count = contributors.count
+      contributors.delete_all
+
+      owner.update!(projects_count: 0)
+    end
+
+    puts "[science] hidden owner #{host.name}/#{owner.login}"
+    puts "[science] destroyed #{project_count} projects for #{host.name}/#{login}"
+    puts "[science] destroyed #{contributor_count} contributors for #{login}"
+  end
+
+  desc "Report what exists for a user. LOGIN=username [HOST=GitHub]"
+  task report: :environment do
+    login = ENV['LOGIN']
+    host_name = ENV['HOST'] || 'GitHub'
+    abort "LOGIN is required" if login.blank?
+
+    host = Host.find_by_name(host_name)
+    abort "Host #{host_name} not found" if host.nil?
+
+    owner = host.owners.find_by('lower(login) = ?', login.downcase)
+    project_count = Project.for_owner(host, login).count
+    contributor_count = Contributor.where(
+      "lower(login) = :login OR lower(profile ->> 'login') = :login",
+      login: login.downcase
+    ).count
+    state = owner ? (owner.hidden? ? 'hidden' : 'visible') : 'none'
+
+    puts "[science] #{host.name}/#{login}: owner=#{state} projects=#{project_count} contributors=#{contributor_count}"
+  end
+end

--- a/test/controllers/owners_controller_test.rb
+++ b/test/controllers/owners_controller_test.rb
@@ -57,4 +57,25 @@ class OwnersControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "h1", /Institutional Owners/
   end
+
+  test "hidden owners are excluded from the index" do
+    host = Host.create!(name: "GitHub")
+    Owner.create!(host: host, login: "visible-owner")
+    Owner.create!(host: host, login: "hidden-owner", hidden: true)
+
+    get host_owners_url(host.name)
+
+    assert_response :success
+    assert_match "visible-owner", response.body
+    assert_no_match "hidden-owner", response.body
+  end
+
+  test "hidden owner returns 404" do
+    host = Host.create!(name: "GitHub")
+    Owner.create!(host: host, login: "HIDDEN-OWNER", hidden: true)
+
+    get host_owner_url(host.name, "hidden-owner")
+
+    assert_response :not_found
+  end
 end

--- a/test/controllers/projects_controller_test.rb
+++ b/test/controllers/projects_controller_test.rb
@@ -67,6 +67,24 @@ class ProjectsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "hidden owner project returns 404 from html and api" do
+    host = Host.create!(name: "GitHub", url: "https://github.com")
+    owner = Owner.create!(host: host, login: "hidden-owner")
+    project = Project.create!(
+      host: host,
+      owner_record: owner,
+      url: "https://github.com/hidden-owner/project",
+      science_score: 50
+    )
+    owner.update!(hidden: true)
+
+    get project_url(project)
+    assert_response :not_found
+
+    get api_v1_project_url(project), as: :json
+    assert_response :not_found
+  end
+
   test "should get search" do
     get search_projects_url
     assert_response :success

--- a/test/models/contributor_test.rb
+++ b/test/models/contributor_test.rb
@@ -1,7 +1,37 @@
 require "test_helper"
 
 class ContributorTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "visible excludes contributors matching a hidden owner" do
+    host = Host.create!(name: "GitHub")
+    Owner.create!(host: host, login: "hidden-user", hidden: true)
+    hidden_contributor = Contributor.create!(
+      login: "HIDDEN-USER",
+      email: "hidden@example.com"
+    )
+    hidden_profile_contributor = Contributor.create!(
+      email: "profile@example.com",
+      profile: { "login" => "hidden-user" }
+    )
+    visible_contributor = Contributor.create!(
+      login: "visible-user",
+      email: "visible@example.com"
+    )
+
+    assert_not_includes Contributor.visible, hidden_contributor
+    assert_not_includes Contributor.visible, hidden_profile_contributor
+    assert_includes Contributor.visible, visible_contributor
+  end
+
+  test "hidden owner contributor does not fetch or import" do
+    host = Host.create!(name: "GitHub")
+    Owner.create!(host: host, login: "hidden-user", hidden: true)
+    contributor = Contributor.create!(
+      login: "HIDDEN-USER",
+      email: "hidden@example.com"
+    )
+
+    assert_nil contributor.fetch_profile
+    assert_nil contributor.import_repos
+    assert_not_requested :get, contributor.repos_api_url
+  end
 end

--- a/test/models/owner_test.rb
+++ b/test/models/owner_test.rb
@@ -7,6 +7,24 @@ class OwnerTest < ActiveSupport::TestCase
     assert owner.valid?
   end
 
+  test "visible scope excludes hidden owners" do
+    host = Host.create!(name: "GitHub")
+    visible_owner = Owner.create!(host: host, login: "visible", hidden: false)
+    hidden_owner = Owner.create!(host: host, login: "hidden", hidden: true)
+
+    assert_includes Owner.visible, visible_owner
+    assert_not_includes Owner.visible, hidden_owner
+  end
+
+  test "hidden scope only includes hidden owners" do
+    host = Host.create!(name: "GitHub")
+    visible_owner = Owner.create!(host: host, login: "visible", hidden: false)
+    hidden_owner = Owner.create!(host: host, login: "hidden", hidden: true)
+
+    assert_includes Owner.hidden, hidden_owner
+    assert_not_includes Owner.hidden, visible_owner
+  end
+
   test "requires login" do
     host = Host.create!(name: "GitHub")
     owner = Owner.new(host: host)

--- a/test/models/project_test.rb
+++ b/test/models/project_test.rb
@@ -490,6 +490,69 @@ class ProjectTest < ActiveSupport::TestCase
     assert_nil project.owner_id
   end
 
+  test "does not create a project for a hidden owner" do
+    host = Host.create!(name: "GitHub", url: "https://github.com")
+    Owner.create!(host: host, login: "hidden-owner", hidden: true)
+
+    project = Project.new(url: "https://github.com/HIDDEN-OWNER/project")
+
+    assert_not project.valid?
+    assert_includes project.errors[:url], "belongs to a hidden owner"
+  end
+
+  test "visible excludes projects belonging to hidden owners" do
+    host = Host.create!(name: "GitHub", url: "https://github.com")
+    owner = Owner.create!(host: host, login: "hidden-owner")
+    project = Project.create!(
+      host: host,
+      owner_record: owner,
+      url: "https://github.com/hidden-owner/project"
+    )
+    owner.update!(hidden: true)
+
+    assert_not_includes Project.visible, project
+  end
+
+  test "visible includes projects without an owner record" do
+    project = Project.create!(url: "https://github.com/unknown-owner/project")
+
+    assert_includes Project.visible, project
+  end
+
+  test "does not enqueue or sync projects belonging to hidden owners" do
+    host = Host.create!(name: "GitHub", url: "https://github.com")
+    owner = Owner.create!(host: host, login: "hidden-owner")
+    project = Project.create!(
+      host: host,
+      owner_record: owner,
+      url: "https://github.com/hidden-owner/project"
+    )
+    owner.update!(hidden: true)
+
+    assert_no_difference -> { SyncProjectWorker.jobs.size } do
+      project.sync_async
+    end
+    assert_not_requested :get, project.url
+    assert_nil project.sync
+  end
+
+  test "find_or_create_owner preserves a hidden tombstone" do
+    host = Host.create!(name: "GitHub")
+    owner = Owner.create!(host: host, login: "hidden-owner", hidden: true)
+    project = Project.create!(url: "https://github.com/other-owner/project", host: host)
+    project.update_column(:owner, {
+      "login" => "hidden-owner",
+      "hidden" => false,
+      "name" => "Hidden Owner"
+    })
+
+    project.find_or_create_owner
+
+    assert owner.reload.hidden?
+    assert_nil owner.name
+    assert_equal owner, project.reload.owner_record
+  end
+
   test "packages_sorted_ids returns cached sorted project ids" do
     project1 = Project.create!(
       url: 'https://github.com/test/project1',

--- a/test/tasks/takedown_rake_test.rb
+++ b/test/tasks/takedown_rake_test.rb
@@ -1,0 +1,114 @@
+require "test_helper"
+require "rake"
+
+class TakedownRakeTest < ActiveSupport::TestCase
+  setup do
+    Rails.application.load_tasks unless Rake::Task.task_defined?("takedown:hide_user")
+    ENV.delete("HOST")
+    ENV.delete("LOGIN")
+  end
+
+  teardown do
+    ENV.delete("HOST")
+    ENV.delete("LOGIN")
+  end
+
+  test "hide_user hides and scrubs an owner and removes their projects" do
+    host = Host.create!(name: "GitHub", url: "https://github.com")
+    owner = Owner.create!(
+      host: host,
+      login: "Target-Owner",
+      name: "Target Owner",
+      email: "target@example.com",
+      metadata: { "profile" => true }
+    )
+    project = Project.create!(
+      host: host,
+      owner_record: owner,
+      url: "https://github.com/target-owner/project",
+      science_score: 50
+    )
+    url_only_project = Project.create!(
+      url: "https://github.com/target-owner/unlinked",
+      science_score: 40
+    )
+    other_project = Project.create!(
+      url: "https://github.com/other-owner/project",
+      science_score: 30
+    )
+    issue = Issue.create!(project: project, title: "Issue")
+    release = Release.create!(project: project, tag_name: "v1.0.0")
+    field = Field.create!(name: "Biology", domain: "life_sciences")
+    project_field = ProjectField.create!(project: project, field: field, confidence_score: 0.8)
+    paper = Paper.create!(title: "Paper")
+    mention = Mention.create!(project: project, paper: paper)
+    vote = Vote.create!(project: project, score: 1)
+    dependency = Dependency.create!(project: project, ecosystem: "rubygems", name: "example")
+    contributor = Contributor.create!(
+      login: "target-owner",
+      email: "target@example.com",
+      profile: { "name" => "Target Owner" }
+    )
+    other_contributor = Contributor.create!(
+      login: "other-owner",
+      email: "other@example.com"
+    )
+    ENV["LOGIN"] = "TARGET-OWNER"
+
+    output, = capture_io { Rake::Task["takedown:hide_user"].execute }
+
+    owner.reload
+    assert owner.hidden?
+    assert_nil owner.name
+    assert_nil owner.email
+    assert_equal({}, owner.metadata)
+    assert_equal 0, owner.projects_count
+    assert_not Project.exists?(project.id)
+    assert_not Project.exists?(url_only_project.id)
+    assert Project.exists?(other_project.id)
+    assert_not Issue.exists?(issue.id)
+    assert_not Release.exists?(release.id)
+    assert_not ProjectField.exists?(project_field.id)
+    assert_not Mention.exists?(mention.id)
+    assert_not Vote.exists?(vote.id)
+    assert_nil dependency.reload.project_id
+    assert_not Contributor.exists?(contributor.id)
+    assert Contributor.exists?(other_contributor.id)
+    assert_equal 0, paper.reload.mentions_count
+    assert_includes output, "[science] hidden owner GitHub/Target-Owner"
+    assert_includes output, "[science] destroyed 2 projects"
+    assert_includes output, "[science] destroyed 1 contributors"
+  end
+
+  test "hide_user creates a hidden tombstone for an unknown owner" do
+    Host.create!(name: "GitHub", url: "https://github.com")
+    ENV["LOGIN"] = "Missing-Owner"
+
+    capture_io { Rake::Task["takedown:hide_user"].execute }
+
+    owner = Owner.find_by(login: "missing-owner")
+    assert owner.hidden?
+  end
+
+  test "hide_user aborts without LOGIN" do
+    assert_raises(SystemExit) do
+      capture_io { Rake::Task["takedown:hide_user"].execute }
+    end
+  end
+
+  test "report describes a hidden owner and their projects" do
+    host = Host.create!(name: "GitHub", url: "https://github.com")
+    owner = Owner.create!(host: host, login: "Hidden-Owner")
+    Project.create!(
+      host: host,
+      owner_record: owner,
+      url: "https://github.com/hidden-owner/project"
+    )
+    owner.update!(hidden: true)
+    ENV["LOGIN"] = "HIDDEN-OWNER"
+
+    output, = capture_io { Rake::Task["takedown:report"].execute }
+
+    assert_includes output, "[science] GitHub/HIDDEN-OWNER: owner=hidden projects=1 contributors=0"
+  end
+end


### PR DESCRIPTION
Adds Science takedown and report tasks. Hidden owners and matching contributors are excluded from imports, sync jobs, and public pages, while takedowns scrub owner profiles and remove cached project data.