### PR TITLE
Add brief scan integration for research tooling detection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,12 @@ RUN apk add --no-cache \
  && pip install docutils \
  && npm install -g repomix
 
+ARG BRIEF_VERSION=0.11.0
+RUN ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') \
+ && curl -sSL "https://github.com/git-pkgs/brief/releases/download/v${BRIEF_VERSION}/brief_${BRIEF_VERSION}_linux_${ARCH}.tar.gz" \
+    | tar -xz -C /usr/local/bin brief \
+ && brief --version
+
 ENV LD_PRELOAD=/usr/lib/libjemalloc.so.2
 ENV RUBY_YJIT_ENABLE=1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN apk add --no-cache \
  && pip install docutils \
  && npm install -g repomix
 
-ARG BRIEF_VERSION=0.11.0
+ARG BRIEF_VERSION=0.12.0
 RUN ARCH=$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/') \
  && curl -sSL "https://github.com/git-pkgs/brief/releases/download/v${BRIEF_VERSION}/brief_${BRIEF_VERSION}_linux_${ARCH}.tar.gz" \
     | tar -xz -C /usr/local/bin brief \

--- a/app/models/concerns/project/sync.rb
+++ b/app/models/concerns/project/sync.rb
@@ -540,15 +540,18 @@ module Project::Sync
     "#{repository['html_url']}/raw/#{repository['default_branch']}/#{path}"
   end 
 
+  BRIEF_TIMEOUT = 120
+
   def fetch_brief
     return unless repository.present?
 
     clone_url = repository['clone_url'].presence || repository_url
-    cmd = ['brief', '-json', '-depth', '1', clone_url]
+    cmd = ['timeout', '-k', '10', BRIEF_TIMEOUT.to_s, 'brief', '-json', '-depth', '1', clone_url]
     out, err, status = Open3.capture3(*cmd)
     unless status.success?
-      Rails.logger.warn "brief failed for #{repository_url}: #{err.to_s.lines.last&.strip}"
-      return
+      msg = status.exitstatus == 124 ? 'timeout' : err.to_s.lines.last&.strip
+      Rails.logger.warn "brief failed for #{repository_url}: #{msg}"
+      return record_brief_error(msg)
     end
 
     data = JSON.parse(out)
@@ -566,6 +569,11 @@ module Project::Sync
     Rails.logger.warn "brief binary not found; skipping fetch_brief for #{repository_url}"
   rescue JSON::ParserError => e
     Rails.logger.warn "brief output not JSON for #{repository_url}: #{e.message}"
+    record_brief_error("parse: #{e.message}")
+  end
+
+  def record_brief_error(msg)
+    update_column(:brief, { 'error' => msg.to_s[0, 500], 'attempted_at' => Time.now.utc.iso8601 })
   end
 
   def sync_issues

--- a/app/models/concerns/project/sync.rb
+++ b/app/models/concerns/project/sync.rb
@@ -1,3 +1,5 @@
+require 'open3'
+
 module Project::Sync
   extend ActiveSupport::Concern
 
@@ -537,6 +539,34 @@ module Project::Sync
     return unless repository.present?
     "#{repository['html_url']}/raw/#{repository['default_branch']}/#{path}"
   end 
+
+  def fetch_brief
+    return unless repository.present?
+
+    clone_url = repository['clone_url'].presence || repository_url
+    cmd = ['brief', '-json', '-depth', '1', clone_url]
+    out, err, status = Open3.capture3(*cmd)
+    unless status.success?
+      Rails.logger.warn "brief failed for #{repository_url}: #{err.to_s.lines.last&.strip}"
+      return
+    end
+
+    data = JSON.parse(out)
+    self.brief = {
+      'version' => data['version'],
+      'languages' => data['languages'],
+      'package_managers' => data['package_managers'],
+      'tools' => data['tools'],
+      'resources' => data['resources'],
+      'manifests' => data['manifests'],
+      'lines' => data['lines'],
+    }
+    save
+  rescue Errno::ENOENT
+    Rails.logger.warn "brief binary not found; skipping fetch_brief for #{repository_url}"
+  rescue JSON::ParserError => e
+    Rails.logger.warn "brief output not JSON for #{repository_url}: #{e.message}"
+  end
 
   def sync_issues
     return unless repository.present?

--- a/app/services/science_score_calculator.rb
+++ b/app/services/science_score_calculator.rb
@@ -315,6 +315,7 @@ class ScienceScoreCalculator
 
   def check_research_tooling
     return { present: false, description: "Research tooling", details: nil } unless project.brief.present?
+    return { present: false, description: "Research tooling", details: "scan error: #{project.brief['error']}" } if project.brief['error']
 
     tools = (project.brief['tools'] || {}).values.flatten
     domains = tools.flat_map { |t| t.dig('taxonomy', 'domain') || [] }.uniq

--- a/app/services/science_score_calculator.rb
+++ b/app/services/science_score_calculator.rb
@@ -90,6 +90,7 @@ class ScienceScoreCalculator
       has_institutional_owner: check_institutional_owner,
       has_scientific_registry: check_scientific_registry,
       has_scientific_dependencies: check_scientific_dependencies,
+      has_research_tooling: check_research_tooling,
       negative_indicators: check_negative_indicators,
       has_joss_paper: check_joss_paper
     }
@@ -138,6 +139,7 @@ class ScienceScoreCalculator
         has_institutional_owner: 0.10,
         has_scientific_registry: 0.07,
         has_scientific_dependencies: 0.0,
+        has_research_tooling: 0.0,
         joss_vocabulary_similarity: 0.13
       }
 
@@ -300,6 +302,40 @@ class ScienceScoreCalculator
       description: "Scientific dependencies",
       details: matches.any? ? "#{matches.length} matched: #{matches.first(5).map { |e, n| "#{e}:#{n}" }.join(', ')}" : nil,
       matches: matches.length,
+    }
+  end
+
+  RESEARCH_DOMAINS = %w[research bioinformatics scientific-computing high-performance-computing].freeze
+
+  RESEARCH_TOOLS = {
+    strong: %w[Snakemake Nextflow nf-core nf-test MultiQC Dockstore],
+    high: ['Quarto', 'R Markdown', 'knitr', 'DVC', 'targets', 'ASV', 'Fortitude'],
+    moderate: %w[Jupyter MyST-Parser BenchmarkTools.jl Documenter.jl roxygen2 pkgdown covr testthat renv],
+  }.freeze
+
+  def check_research_tooling
+    return { present: false, description: "Research tooling", details: nil } unless project.brief.present?
+
+    tools = (project.brief['tools'] || {}).values.flatten
+    domains = tools.flat_map { |t| t.dig('taxonomy', 'domain') || [] }.uniq
+    if (domains & RESEARCH_DOMAINS).any?
+      return {
+        present: true,
+        strength: 1.0,
+        description: "Research tooling",
+        details: "Tools tagged domain: #{(domains & RESEARCH_DOMAINS).join(', ')}",
+      }
+    end
+
+    names = tools.map { |t| t['name'] }.compact
+    tier, matches = RESEARCH_TOOLS.lazy.map { |k, v| [k, names & v] }.find { |_, m| m.any? }
+    strength = { strong: 1.0, high: 0.7, moderate: 0.4 }[tier]
+
+    {
+      present: matches.present?,
+      strength: strength,
+      description: "Research tooling",
+      details: matches.present? ? "Detected: #{matches.join(', ')}" : nil,
     }
   end
 

--- a/db/migrate/20260824152455_add_brief_to_projects.rb
+++ b/db/migrate/20260824152455_add_brief_to_projects.rb
@@ -1,0 +1,5 @@
+class AddBriefToProjects < ActiveRecord::Migration[8.1]
+  def change
+    add_column :projects, :brief, :jsonb
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_12_10_112449) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_24_152455) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -176,6 +176,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_12_10_112449) do
   end
 
   create_table "projects", force: :cascade do |t|
+    t.jsonb "brief"
     t.string "category"
     t.text "citation_file"
     t.text "codemeta"

--- a/lib/tasks/projects.rake
+++ b/lib/tasks/projects.rake
@@ -96,6 +96,15 @@ namespace :projects do
     Project.sync_dependencies
   end
 
+  desc 'run brief against projects without brief data (LIMIT=100)'
+  task :fetch_brief => :environment do
+    limit = (ENV['LIMIT'] || 100).to_i
+    Project.with_repository.where(brief: nil).where('science_score > 0').limit(limit).find_each do |project|
+      puts project.url
+      project.fetch_brief
+    end
+  end
+
   desc 'import reviewed projects from OST (Open Sustainable Technology)'
   task :import_ost => :environment do
     Project.import_from_ost

--- a/test/models/project_sync_test.rb
+++ b/test/models/project_sync_test.rb
@@ -284,8 +284,11 @@ class ProjectSyncTest < ActiveSupport::TestCase
       tools: { test: [{ name: "pytest" }] }, resources: {}, manifests: [], lines: {},
       dependencies: [{ name: "numpy" }], git: {}, stats: {}
     }.to_json
-    Open3.expects(:capture3).with("brief", "-json", "-depth", "1", "https://github.com/numpy/numpy.git")
-         .returns([output, "", stub(success?: true)])
+    Open3.expects(:capture3).with do |*args|
+      assert_equal "https://github.com/numpy/numpy.git", args.last
+      assert_includes args, "brief"
+      assert_includes args, "timeout"
+    end.returns([output, "", stub(success?: true)])
 
     p.fetch_brief
     assert_equal "0.11.0", p.reload.brief["version"]
@@ -306,11 +309,26 @@ class ProjectSyncTest < ActiveSupport::TestCase
     assert_nil p.brief
   end
 
-  test "fetch_brief handles non-zero exit" do
+  test "fetch_brief records error on non-zero exit" do
     p = build_project
-    Open3.expects(:capture3).returns(["", "clone failed", stub(success?: false)])
+    Open3.expects(:capture3).returns(["", "fatal: clone failed", stub(success?: false, exitstatus: 128)])
     assert_nothing_raised { p.fetch_brief }
-    assert_nil p.brief
+    assert_equal "fatal: clone failed", p.reload.brief["error"]
+    assert p.brief["attempted_at"].present?
+  end
+
+  test "fetch_brief records timeout error" do
+    p = build_project
+    Open3.expects(:capture3).returns(["", "", stub(success?: false, exitstatus: 124)])
+    p.fetch_brief
+    assert_equal "timeout", p.reload.brief["error"]
+  end
+
+  test "fetch_brief records error on parse failure" do
+    p = build_project
+    Open3.expects(:capture3).returns(["not json", "", stub(success?: true)])
+    p.fetch_brief
+    assert_match "parse:", p.reload.brief["error"]
   end
 
   test "sync_issues returns early when issues list response is not an array" do

--- a/test/models/project_sync_test.rb
+++ b/test/models/project_sync_test.rb
@@ -277,6 +277,42 @@ class ProjectSyncTest < ActiveSupport::TestCase
     assert_nil p.sync
   end
 
+  test "fetch_brief stores trimmed brief output" do
+    p = build_project(repository: repo_hash.merge("clone_url" => "https://github.com/numpy/numpy.git"))
+    output = {
+      version: "0.11.0", languages: [{ name: "Python" }], package_managers: [],
+      tools: { test: [{ name: "pytest" }] }, resources: {}, manifests: [], lines: {},
+      dependencies: [{ name: "numpy" }], git: {}, stats: {}
+    }.to_json
+    Open3.expects(:capture3).with("brief", "-json", "-depth", "1", "https://github.com/numpy/numpy.git")
+         .returns([output, "", stub(success?: true)])
+
+    p.fetch_brief
+    assert_equal "0.11.0", p.reload.brief["version"]
+    assert_equal "pytest", p.brief.dig("tools", "test", 0, "name")
+    refute p.brief.key?("dependencies")
+    refute p.brief.key?("git")
+  end
+
+  test "fetch_brief returns early when repository absent" do
+    Open3.expects(:capture3).never
+    assert_nil Project.new(url: "https://github.com/x/y").fetch_brief
+  end
+
+  test "fetch_brief handles missing binary" do
+    p = build_project
+    Open3.expects(:capture3).raises(Errno::ENOENT)
+    assert_nothing_raised { p.fetch_brief }
+    assert_nil p.brief
+  end
+
+  test "fetch_brief handles non-zero exit" do
+    p = build_project
+    Open3.expects(:capture3).returns(["", "clone failed", stub(success?: false)])
+    assert_nothing_raised { p.fetch_brief }
+    assert_nil p.brief
+  end
+
   test "sync_issues returns early when issues list response is not an array" do
     p = build_project
     stub_request(:get, p.issues_api_url).to_return(

--- a/test/services/science_score_calculator_test.rb
+++ b/test/services/science_score_calculator_test.rb
@@ -266,6 +266,32 @@ class ScienceScoreCalculatorTest < ActiveSupport::TestCase
     assert_equal 0.7, result[:strength]
   end
 
+  test "check_research_tooling detects tools by taxonomy domain" do
+    @project.brief = { "tools" => { "build" => [{ "name" => "Snakemake", "taxonomy" => { "domain" => ["research"] } }] } }
+    result = ScienceScoreCalculator.new(@project).check_research_tooling
+    assert result[:present]
+    assert_equal 1.0, result[:strength]
+    assert_match "domain: research", result[:details]
+  end
+
+  test "check_research_tooling falls back to name matching by tier" do
+    @project.brief = { "tools" => { "docs" => [{ "name" => "Quarto" }] } }
+    result = ScienceScoreCalculator.new(@project).check_research_tooling
+    assert result[:present]
+    assert_equal 0.7, result[:strength]
+
+    @project.brief = { "tools" => { "environment" => [{ "name" => "Jupyter" }] } }
+    result = ScienceScoreCalculator.new(@project).check_research_tooling
+    assert_equal 0.4, result[:strength]
+
+    @project.brief = { "tools" => { "test" => [{ "name" => "pytest" }] } }
+    refute ScienceScoreCalculator.new(@project).check_research_tooling[:present]
+  end
+
+  test "check_research_tooling absent when no brief data" do
+    refute ScienceScoreCalculator.new(@project).check_research_tooling[:present]
+  end
+
   test "check_negative_indicators detects strong topics" do
     @project.repository = { 'topics' => ['awesome-list', 'python'] }
     result = ScienceScoreCalculator.new(@project).check_negative_indicators

--- a/test/services/science_score_calculator_test.rb
+++ b/test/services/science_score_calculator_test.rb
@@ -292,6 +292,13 @@ class ScienceScoreCalculatorTest < ActiveSupport::TestCase
     refute ScienceScoreCalculator.new(@project).check_research_tooling[:present]
   end
 
+  test "check_research_tooling absent when brief scan errored" do
+    @project.brief = { "error" => "clone failed", "attempted_at" => Time.now.iso8601 }
+    result = ScienceScoreCalculator.new(@project).check_research_tooling
+    refute result[:present]
+    assert_match "scan error", result[:details]
+  end
+
   test "check_negative_indicators detects strong topics" do
     @project.repository = { 'topics' => ['awesome-list', 'python'] }
     result = ScienceScoreCalculator.new(@project).check_negative_indicators


### PR DESCRIPTION
Adds a `brief` jsonb column on projects, a `fetch_brief` sync method that shells out to `brief -json -depth 1 <clone_url>` (bounded by a 120s timeout) and stores the trimmed output, and a `check_research_tooling` signal in `ScienceScoreCalculator`.

The check reads `brief.tools[*].taxonomy.domain` for `research`/`bioinformatics`/`scientific-computing`/`high-performance-computing` and falls back to name-matching against known research tools (Snakemake, Nextflow, nf-core, MultiQC, Dockstore, Quarto, DVC, targets, ASV, Fortitude, Jupyter, and the R/Julia package tooling clusters) for detectors that don't yet carry a domain tag.

`fetch_brief` is not called from the main sync loop since a shallow clone per project is too heavy for the shared worker. `rake projects:fetch_brief` populates it at a controllable rate (`LIMIT` env var, default 100). Failed scans store `{error, attempted_at}` so they don't block the backfill queue. The `has_research_tooling` scoring weight is 0 until that starts running.

Dockerfile installs brief 0.12.0 from GitHub releases.